### PR TITLE
Added syncdir for getting contagts from G Suite global Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ client_secrets*
 !docs/client_secrets*
 *.pyc
 .swp
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p /data/web
 
 COPY requirements.txt /data/
 COPY sync.py /data/
+COPY sync_directory.py /data/
 COPY web/ /data/web/
 COPY run.sh /data/
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker build -t snom-gcontacts .
 The image runs an entrypoint script which accepts the following parameters:
 
 * sync: runs the synchronisation script
-* syncdir: runs the synchronisation script with G Suite global Directory
+* syncdir: runs the synchronisation script with G Suite global Directory (needs Google Admin SDK API enabled)
 * run: run the web application serving the phone book and the caller-lookup service
 * runandsync: first run the sync and then the the run script
 * phoneconf: configure the settings `dkey_directory` and the `action_incoming_url`pointing to the web application (application URL must be defined via the `APP_URL` environment variable)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Contacts integration Proof of Concept
 
 #### DISCLAIMER:
-This is just a proof of concept application demostrating a possible Google Contacts integration.
+This is just a proof of concept application demostrating a possible Google Contacts or G Suite global Directory integration.
 *The application is not suitable for production environments*.
 
 ## Concept
@@ -65,6 +65,7 @@ docker build -t snom-gcontacts .
 The image runs an entrypoint script which accepts the following parameters:
 
 * sync: runs the synchronisation script
+* syncdir: runs the synchronisation script with G Suite global Directory
 * run: run the web application serving the phone book and the caller-lookup service
 * runandsync: first run the sync and then the the run script
 * phoneconf: configure the settings `dkey_directory` and the `action_incoming_url`pointing to the web application (application URL must be defined via the `APP_URL` environment variable)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ six==1.10.0
 uritemplate==0.6
 virtualenv==15.0.3
 web.py==0.38
+google-api-python-client==1.5.5

--- a/run.sh
+++ b/run.sh
@@ -9,11 +9,11 @@ Usage: $0 <sync|syncdir|run|syncandrun|shell|phoneconf>"
             from the Google API console (https://console.developers.google.com/apis/ )
             The file can be generated creating an OAuth ID, selecting Application type = other
 
-    syncdir:  The sync command downloads locally the gsuite contacts domain directory
-            In order to access the Google contacts directory the script
+    syncdir:  The sync command downloads locally the G Suite global Directory
+            In order to access the G Suite global Directory the script
             needs the client secrets file. Such file can be obtained
             from the Google API console (https://console.developers.google.com/apis/ )
-            You need to activate  Admin SDK API.
+            You need to activate Admin SDK API.
             The file can be generated creating an OAuth ID, selecting Application type = other
 
     run:    The run command start the local http server serving the XML applications

--- a/run.sh
+++ b/run.sh
@@ -2,11 +2,18 @@
 
 function do_help(){
 cat << EOF
-Usage: $0 <sync|run|syncandrun|shell|phoneconf>"
-    sync:   The sync commnd downloads locally the contacts
+Usage: $0 <sync|syncdir|run|syncandrun|shell|phoneconf>"
+    sync:   The sync command downloads locally the contacts
             In order to access the Google contacts the script
             needs the client secrets file. Such file can be obtained
             from the Google API console (https://console.developers.google.com/apis/ )
+            The file can be generated creating an OAuth ID, selecting Application type = other
+
+    syncdir:  The sync command downloads locally the gsuite contacts domain directory
+            In order to access the Google contacts directory the script
+            needs the client secrets file. Such file can be obtained
+            from the Google API console (https://console.developers.google.com/apis/ )
+            You need to activate  Admin SDK API.
             The file can be generated creating an OAuth ID, selecting Application type = other
 
     run:    The run command start the local http server serving the XML applications
@@ -45,6 +52,11 @@ case $1 in
         python /data/sync.py --noauth_local_webserver $@
         ;;
 
+    syncdir)
+        shift
+        python /data/sync_directory.py --noauth_local_webserver $@
+        ;;
+
     run)
         shift
         cd /data/web && python /data/web/app.py $@
@@ -60,7 +72,7 @@ case $1 in
         ;;
 
     *)
-        echo "ERROR: you can use the following commands: sync, run, shell"
+        echo "ERROR: you can use the following commands: sync, syncdir, run, shell"
         do_help
         ;;
 esac

--- a/sync_directory.py
+++ b/sync_directory.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
+import os
+import os.path
+import json
+import httplib2
+import codecs
+
+from pprint import pprint
+from oauth2client import client
+from oauth2client import file
+from oauth2client import tools
+
+from apiclient import discovery
+from oauth2client.file import Storage
+
+
+# Native application Client ID JSON from the Google Developers Console,
+# store in the same directory as this script:
+CLIENT_SECRETS_JSON = 'client_secrets.json'
+SCOPES = 'https://www.googleapis.com/auth/admin.directory.user'
+APPLICATION_NAME = 'Directory API SnomSync'
+
+parser = tools.argparser
+args = parser.parse_args()
+
+if not os.path.isfile(CLIENT_SECRETS_JSON):
+    if 'CLIENT_SECRETS_JSON' in os.environ.keys():
+        CLIENT_SECRETS_JSON = os.environ['CLIENT_SECRETS_JSON']
+    else:
+        print("ERROR: Clien Secrets JSON file missing.")
+        print("\tplease create it with name 'client_secrets.json' or define the env. variable CLIENT_SECRETS_JSON")
+        sys.exit(-1)
+
+
+class SyncGoogleDirectoryContacts:
+    def __init__(self, client_secrets):
+        self._token_filename = os.path.splitext(client_secrets)[0] + '-directory.dat'
+        self.datastore = os.path.splitext(client_secrets)[0] + '-datastore.json'
+        self._client_secrets = client_secrets
+        self._scope = 'https://www.googleapis.com/auth/admin.directory.user https://www.googleapis.com/auth/admin.directory.user'
+        self._user_agent = 'SnomSync'
+
+    def get_credentials(self):
+        """Gets valid user credentials from storage.
+
+        If nothing has been stored, or if the stored credentials are invalid,
+        the OAuth2 flow is completed to obtain the new credentials.
+
+        Returns:
+            Credentials, the obtained credential.
+        """
+        # home_dir = os.path.expanduser('~')
+        # credential_dir = os.path.join(home_dir, '.credentials')
+        # if not os.path.exists(credential_dir):
+        #     os.makedirs(credential_dir)
+        # credential_path = os.path.join(credential_dir,
+        #                                'admin-directory_v1-python-quickstart.json')
+
+        credential_path = self._token_filename
+        store = Storage(credential_path)
+        credentials = store.get()
+        if not credentials or credentials.invalid:
+            flow = client.flow_from_clientsecrets(CLIENT_SECRETS_JSON, SCOPES)
+            flow.user_agent = APPLICATION_NAME
+            #if flags:
+            if args:
+                #credentials = tools.run_flow(flow, store, flags)
+                credentials = tools.run_flow(flow, store, args)
+            else:  # Needed only for compatibility with Python 2.6
+                credentials = tools.run(flow, store)
+            print('Storing credentials to ' + credential_path)
+        return credentials
+
+    def get_auth_token(self, non_interactive=False):
+        flow = client.flow_from_clientsecrets(self._client_secrets, scope=self._scope,
+                                              message=tools.message_if_missing(self._client_secrets))
+        storage = file.Storage(self._token_filename)
+        self.credentials = storage.get()
+        if self.credentials is None or self.credentials.invalid:
+            if non_interactive:
+                sys.stderr.write(
+                    'ERROR: Invalid or missing Oauth2 credentials. To reset auth flow manually, run without --non_interactive\n')
+            else:
+                self.credentials = tools.run_flow(flow, storage, args)
+        self.token = httplib2.Http()
+        self.token = self.credentials.authorize(self.token)
+
+    def get_groups(self):
+        return []
+
+        res, content = self.token.request('https://www.google.com/m8/feeds/groups/default/thin?alt=json', method='GET')
+        if res['status'] == "200":
+            data = json.loads(content.decode('utf8'))
+            groups = []
+            if 'entry' not in data['feed']:
+                return groups
+            for gdata in data['feed']['entry']:
+                name = gdata['title']['$t']
+                id = gdata['id']['$t']
+                groups.append(
+                    {'name': name, 'id': id}
+                )
+            return groups
+        else:
+            raise Exception("Error getting the list of groups, received: %s\n\n" % (res, content))
+
+    def get_contacts(self, group_id=None):
+        if group_id:
+            query_str = '&group={0}'.format(group_id)
+        else:
+            query_str = ''
+
+        """Shows basic usage of the Google Admin SDK Directory API.
+
+            Creates a Google Admin SDK API service object and outputs a list of first
+            10 users in the domain.
+            """
+        credentials = self.get_credentials()
+
+        http = credentials.authorize(httplib2.Http())
+        service = discovery.build('admin', 'directory_v1', http=http)
+
+        print('Getting the first 10 users in the domain')
+        results = service.users().list(
+            customer='my_customer',
+            maxResults=100,
+            showDeleted=False,
+            orderBy='givenName',
+            viewType='domain_public'
+        ).execute()
+        users = results.get('users', [])
+
+        if not users:
+            print('No users in the domain.')
+        else:
+            print('Users:')
+            for user in users:
+                print('{0} ({1})'.format(user['primaryEmail'],
+                                         user['name']['fullName']))
+
+            contacts = []
+            id = 0
+            for user in users:
+                c = {}
+                #c['id'] = id
+                c['id'] = int(user['id'])
+
+                c['emails'] = [user['primaryEmail']]
+
+                if 'phones' in user:
+                    phones = [e['value'] for e in user['phones']]
+                else:
+                    phones = []
+                c['phones'] = phones
+
+                #todo: fix title
+                # if 'title' in user:
+                #     title = user['organisations'][0]['name']
+                # else:
+                #     title = None
+                c['title'] = user['name']['fullName']
+
+                if 'organizations' in user:
+
+                    organizations = [{'name': organization.get('name'),
+                                      'title': organization.get('title')} for organization in
+                                     user['organizations']]
+                else:
+                    organizations = []
+
+                c['organizations'] = organizations
+                id = id + 1
+                contacts.append(c)
+            return contacts
+
+    def store_all_contacts(self):
+        self.store = {}
+        my_contacts = self.get_contacts()
+        self.store['Directory'] = my_contacts
+        print("Found %d Personal Contacts" % len(my_contacts))
+        # groups = self.get_groups()
+        # for g in groups:
+        #     self.store[g['name']] = self.get_contacts(group_id=g['id'])
+        #     print("Found %d contacts in group '%s'" % (len(self.store[g['name']]), g['name']))
+        fd = open(self.datastore, 'w+')
+        json.dump(self.store, fd)
+        fd.close()
+
+
+def main():
+    g = SyncGoogleDirectoryContacts(CLIENT_SECRETS_JSON)
+    g.get_auth_token()
+    g.store_all_contacts()
+
+
+if __name__ == '__main__':
+    main()

--- a/sync_directory.py
+++ b/sync_directory.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 import sys
+
 reload(sys)
 sys.setdefaultencoding('utf-8')
 
@@ -20,7 +21,6 @@ from oauth2client import tools
 
 from apiclient import discovery
 from oauth2client.file import Storage
-
 
 # Native application Client ID JSON from the Google Developers Console,
 # store in the same directory as this script:
@@ -70,9 +70,9 @@ class SyncGoogleDirectoryContacts:
         if not credentials or credentials.invalid:
             flow = client.flow_from_clientsecrets(CLIENT_SECRETS_JSON, SCOPES)
             flow.user_agent = APPLICATION_NAME
-            #if flags:
+            # if flags:
             if args:
-                #credentials = tools.run_flow(flow, store, flags)
+                # credentials = tools.run_flow(flow, store, flags)
                 credentials = tools.run_flow(flow, store, args)
             else:  # Needed only for compatibility with Python 2.6
                 credentials = tools.run(flow, store)
@@ -94,6 +94,9 @@ class SyncGoogleDirectoryContacts:
         self.token = self.credentials.authorize(self.token)
 
     def get_groups(self):
+        """ todo: Groups implementation goes here
+        """
+
         return []
 
         res, content = self.token.request('https://www.google.com/m8/feeds/groups/default/thin?alt=json', method='GET')
@@ -113,22 +116,21 @@ class SyncGoogleDirectoryContacts:
             raise Exception("Error getting the list of groups, received: %s\n\n" % (res, content))
 
     def get_contacts(self, group_id=None):
+        """ Creates a Google Admin SDK API service object and outputs a list of first
+            100 users in the domain.
+        """
+
         if group_id:
             query_str = '&group={0}'.format(group_id)
         else:
             query_str = ''
 
-        """Shows basic usage of the Google Admin SDK Directory API.
-
-            Creates a Google Admin SDK API service object and outputs a list of first
-            10 users in the domain.
-            """
         credentials = self.get_credentials()
 
         http = credentials.authorize(httplib2.Http())
         service = discovery.build('admin', 'directory_v1', http=http)
 
-        print('Getting the first 10 users in the domain')
+        print('Getting the first 100 users in the domain')
         results = service.users().list(
             customer='my_customer',
             maxResults=100,
@@ -150,7 +152,7 @@ class SyncGoogleDirectoryContacts:
             id = 0
             for user in users:
                 c = {}
-                #c['id'] = id
+                # c['id'] = id
                 c['id'] = int(user['id'])
 
                 c['emails'] = [user['primaryEmail']]
@@ -161,7 +163,7 @@ class SyncGoogleDirectoryContacts:
                     phones = []
                 c['phones'] = phones
 
-                #todo: fix title
+                # todo: fix title
                 # if 'title' in user:
                 #     title = user['organisations'][0]['name']
                 # else:


### PR DESCRIPTION
It is better for corporate G Suite users to have contacts from the G Suite global Directory.
https://support.google.com/a/answer/1628009?hl=en

I've added script for getting contacts from G Suite global Directory.

You can test it by changing sync with sycdir in your examples.
Hint: You need to enable Admin SDK API in API Google API Console

```
docker run -it -p 8080:8080 \
	-v $(pwd)/client_secrets.json:/data/client_secrets.json \
	-v $(pwd)/client_secrets-datastore.json:/data/client_secrets-datastore.json \
	-v $(pwd)/client_secrets.dat:/data/client_secrets.dat \
	-e CLIENT_SECRETS_JSON=/data/client_secrets.json \
	-e PHONE_URL=http://172.16.18.62 \
	-e APP_URL=http://172.16.18.15:8080 \
	snom-gcontacts syncdir
```
